### PR TITLE
Bug fix: RTC alarm wake-up

### DIFF
--- a/s3c2410_rtc.c
+++ b/s3c2410_rtc.c
@@ -265,10 +265,10 @@ s3c2410_rtc_read(void *opaque, target_phys_addr_t offset)
 
 	if (S3C2410_RTC_BCDSEC <= offset && offset <= S3C2410_RTC_BCDYEAR) {
 		struct tm *tm;
-		time_t t;
+		struct timeval tv;
 
-		t = time(0);
-		tm = localtime(&t);
+		gettimeofday(&tv, NULL);
+		tm = localtime(&tv.tv_sec);
 
 		switch (offset) {
 		case S3C2410_RTC_BCDSEC:


### PR DESCRIPTION
Because of the S3C2410 bug (INT_SRCPND_RTC not set on alarm wake-up), the firmware need to check on power-on if an alarm is triggered by comparing the alarm date to the system date.
But, It failed because the firmware read a system date that is 1 second behind the alarm date, while the cpu was waked-up by an alarm.
This is because x49gp uses 2 different functions to read host system time in 2 key routines, leading to a 1 second gap when used consecutively.
This fix solved this issue.